### PR TITLE
Add middleware to reject HTTP TRACE requests

### DIFF
--- a/ironcage/middleware.py
+++ b/ironcage/middleware.py
@@ -1,0 +1,14 @@
+from django.http import HttpResponse
+
+
+def http_trace_middleware(get_response):
+    '''This middleware returns 405 (method not allowed) in reponse to an HTTP
+    TRACE request.  This is required forr PCI DSS compliance.'''
+
+    def middleware(request):
+        if request.method == 'TRACE':
+            return HttpResponse(status=405)
+
+        return get_response(request)
+
+    return middleware

--- a/ironcage/settings/base.py
+++ b/ironcage/settings/base.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'ironcage.middleware.http_trace_middleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/ironcage/tests/test_middleware.py
+++ b/ironcage/tests/test_middleware.py
@@ -1,0 +1,7 @@
+from django.test import TestCase
+
+
+class MiddlewareTests(TestCase):
+    def test_trace(self):
+        rsp = self.client.trace('/')
+        self.assertEqual(rsp.status_code, 405)


### PR DESCRIPTION
I haven't been able to try this locally (or even run the tests).  @kirknorthrop, could you test for me please?