### PR TITLE
Fix order with others bug

### DIFF
--- a/tickets/forms.py
+++ b/tickets/forms.py
@@ -103,6 +103,10 @@ class BaseTicketForOthersFormset(forms.BaseFormSet):
                 # This was an empty form, so we ignore it
                 continue
 
+            if form.cleaned_data['DELETE']:
+                # This was deleted so should be ignored
+                continue
+
             email_addr = form.cleaned_data['email_addr']
             name = form.cleaned_data['name']
             days = form.cleaned_data['days']

--- a/tickets/tests/test_forms.py
+++ b/tickets/tests/test_forms.py
@@ -237,8 +237,9 @@ class TicketForOthersFormSetTests(TestCase):
             'form-0-email_addr': 'test1@example.com',
             'form-0-name': 'Test 1',
             'form-0-days': ['sat', 'sun'],
-            'form-1-email_addr': '',
+            'form-1-email_addr': 'test2@example.com',
             'form-1-name': 'Test 2',
+            'form-1-days': ['sat', 'sun'],
             'form-1-DELETE': 'on',
         })
 


### PR DESCRIPTION
Fixes #44. This was caused by a failure in our tests - if testing that deletion happens, ensure we give a valid formset to delete.